### PR TITLE
Fix compile errors in ESP32 I2S Camera

### DIFF
--- a/ESP32_I2S_Camera/src/I2SCamera.cpp
+++ b/ESP32_I2S_Camera/src/I2SCamera.cpp
@@ -7,6 +7,7 @@
 #include "Log.h"
 #include "esp_intr_alloc.h"
 #include "esp_attr.h"
+#include "soc/gpio_struct.h"
 
 int I2SCamera::blocksReceived = 0;
 int I2SCamera::framesReceived = 0;

--- a/ESP32_I2S_Camera/src/XClk.cpp
+++ b/ESP32_I2S_Camera/src/XClk.cpp
@@ -6,16 +6,17 @@
 #include "XClk.h"
 #include "driver/ledc.h"
 #include "driver/periph_ctrl.h"
+#include "esp_idf_version.h"
 
 bool ClockEnable(int pin, int Hz)
 {
     periph_module_enable(PERIPH_LEDC_MODULE);
 
     ledc_timer_config_t timer_conf;
-#if ESP_IDF_VERSION_MAJOR >= 5
-    timer_conf.duty_resolution = (ledc_timer_bit_t)1;
-#else
+#if defined(ESP_IDF_VERSION_MAJOR) && ESP_IDF_VERSION_MAJOR < 4
     timer_conf.bit_num = (ledc_timer_bit_t)1;
+#else
+    timer_conf.duty_resolution = (ledc_timer_bit_t)1;
 #endif
     timer_conf.freq_hz = Hz;
     timer_conf.speed_mode = LEDC_HIGH_SPEED_MODE;


### PR DESCRIPTION
## Summary
- include missing `gpio_struct.h` for direct GPIO register access
- add ESP-IDF version handling for LEDC timer configuration

## Testing
- `make test` *(fails: No rule to make target)*
- `arduino-cli compile` *(fails: command not found)*
- `platformio test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6869a7ec31cc8332b7b575bb1b09f792