### PR TITLE
Fix compile error on ESP32

### DIFF
--- a/ESP32_I2S_Camera/src/I2SCamera.cpp
+++ b/ESP32_I2S_Camera/src/I2SCamera.cpp
@@ -8,6 +8,7 @@
 #include "esp_intr_alloc.h"
 #include "esp_attr.h"
 #include "soc/gpio_struct.h"
+#include "driver/gpio.h"
 
 int I2SCamera::blocksReceived = 0;
 int I2SCamera::framesReceived = 0;


### PR DESCRIPTION
## Summary
- include `driver/gpio.h` in `I2SCamera.cpp` so `gpio_matrix_in` is declared

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6869a968abbc83329e9b75d85c43b31f