### PR TITLE
Fix missing gpio_matrix_in declaration

### DIFF
--- a/ESP32_I2S_Camera/src/I2SCamera.cpp
+++ b/ESP32_I2S_Camera/src/I2SCamera.cpp
@@ -8,6 +8,7 @@
 #include "esp_intr_alloc.h"
 #include "esp_attr.h"
 #include "soc/gpio_struct.h"
+#include "esp32-hal-gpio.h"
 #include "driver/gpio.h"
 
 int I2SCamera::blocksReceived = 0;


### PR DESCRIPTION
## Summary
- include esp32-hal-gpio header so gpio_matrix_in is available

## Testing
- `arduino-cli` not installed; no tests run

------
https://chatgpt.com/codex/tasks/task_b_6869aacf79688332ab23b2fc42e6b05d